### PR TITLE
Fix: persistencia de usuario bug 3 recarga de pagina

### DIFF
--- a/src/routes/RoleGuard.tsx
+++ b/src/routes/RoleGuard.tsx
@@ -9,7 +9,7 @@ interface RoleGuardProps {
 
 const RoleGuard: React.FC<RoleGuardProps> = ({ allowedRoles, children }) => {
   const user = useUserStore((state) => state.user);
-  const userRoles = user!.roles || [];
+  const userRoles = user?.roles || [];
 
   if (!user) {
     return <Navigate to="/login" replace />;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { Seminar } from "../models/studentProcess";
 import { UserResponse } from "../services/models/LoginResponse";
 
@@ -13,13 +14,21 @@ interface IUserStore {
   clearUser: () => void;
 }
 
-export const useUserStore = create<IUserStore>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
-}));
+export const useUserStore = create<IUserStore>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: "user-storage", // clave en localStorage
+    }
+  )
+);
 
 export const useProcessStore = create<IProcessStore>((set) => ({
   process: null,
   setProcess: (newProcess: Seminar) => set({ process: newProcess }),
 }));
+


### PR DESCRIPTION
Este PR resuelve el bug donde al recargar la página, la sesión del usuario se perdía y la aplicación lanzaba un error en el módulo de Docente.

### Cambios realizados:
- Se agregó persistencia del estado `user` en Zustand (`store.ts`) usando middleware `persist`.
- Se corrigió el acceso inseguro a `user.roles` en `RoleGuard.tsx`.

### Resultado:
La sesión ahora se mantiene tras recargar la página y la navegación funciona correctamente.
