### PR TITLE
Bug 2 columnas vacias

### DIFF
--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -45,6 +45,10 @@ const ProfessorPage = () => {
     fetchPermissions();
     fetchProfessors();
   }, []);
+
+const hasViewPermission = HasPermission(viewProfessorReportPermission?.name || "");
+const hasEditPermission = HasPermission(editProfessorPermission?.name || "");
+const hasDeletePermission = HasPermission(deleteProfessorPermission?.name || "");
   
   const columns: GridColDef[] = [
     {
@@ -84,67 +88,60 @@ const ProfessorPage = () => {
       flex: 1,
     },
     {
-      field: "tutoring_count",
-      headerName: "Tutorias",
-      type: "number",
-      headerAlign: "center",
-      align: "center",
-      flex: 1,
+      field: "tutorias",
+      headerName: "Tutorías",
       renderCell: (params) => (
-        params.value && params.value > 0 ? params.value : "No existen tutorías registradas"
+        <div
+          style={{
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            maxWidth: 100,
+            textAlign: "center",
+            lineHeight: "1.2",
+          }}
+        >
+          {params.value ? params.value : "No existen\ntutorías registradas"}
+        </div>
       ),
     },
-    
     {
-      field: "review_count",
+      field: "revisiones",
       headerName: "Revisiones",
-      type: "number",
-      headerAlign: "center",
-      align: "center",
-      flex: 1,
       renderCell: (params) => (
-        params.value && params.value > 0 ? params.value : "No existen revisiones disponibles"
+        <div
+          style={{
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            maxWidth: 100,
+            textAlign: "center",
+            lineHeight: "1.2",
+          }}
+        >
+          {params.value ? params.value : "No existen\nrevisiones disponibles"}
+        </div>
       ),
     },
     
     {
       field: "actions",
       headerName: "Acciones",
-      headerAlign: "center",
-      align: "center",
-      flex: 1,
       renderCell: (params) => {
-        const hasActions =
-          HasPermission(viewProfessorReportPermission?.name || "") ||
-          HasPermission(editProfessorPermission?.name || "") ||
-          HasPermission(deleteProfessorPermission?.name || "");
-    
+        const hasActions = hasViewPermission || hasEditPermission || hasDeletePermission;
+  
         return hasActions ? (
           <div>
-            {HasPermission(viewProfessorReportPermission?.name || "") && (
-              <IconButton
-                color="primary"
-                aria-label="ver"
-                onClick={() => handleView(params.row.id)}
-              >
+            {hasViewPermission && (
+              <IconButton color="primary" onClick={() => handleView(params.row.id)}>
                 <VisibilityIcon />
               </IconButton>
             )}
-            {HasPermission(editProfessorPermission?.name || "") && (
-              <IconButton
-                color="primary"
-                aria-label="editar"
-                onClick={() => handleEdit(params.row.id)}
-              >
+            {hasEditPermission && (
+              <IconButton color="primary" onClick={() => handleEdit(params.row.id)}>
                 <EditIcon />
               </IconButton>
             )}
-            {HasPermission(deleteProfessorPermission?.name || "") && (
-              <IconButton
-                color="secondary"
-                aria-label="eliminar"
-                onClick={() => handleClickOpen(params.row.id)}
-              >
+            {hasDeletePermission && (
+              <IconButton color="secondary" onClick={() => handleClickOpen(params.row.id)}>
                 <DeleteIcon />
               </IconButton>
             )}

--- a/src/pages/Professor/ProfessorPage.tsx
+++ b/src/pages/Professor/ProfessorPage.tsx
@@ -90,7 +90,11 @@ const ProfessorPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      renderCell: (params) => (
+        params.value && params.value > 0 ? params.value : "No existen tutorías registradas"
+      ),
     },
+    
     {
       field: "review_count",
       headerName: "Revisiones",
@@ -98,46 +102,60 @@ const ProfessorPage = () => {
       headerAlign: "center",
       align: "center",
       flex: 1,
+      renderCell: (params) => (
+        params.value && params.value > 0 ? params.value : "No existen revisiones disponibles"
+      ),
     },
+    
     {
       field: "actions",
       headerName: "Acciones",
       headerAlign: "center",
       align: "center",
       flex: 1,
-      renderCell: (params) => (
-        <div>
-          {HasPermission(viewProfessorReportPermission?.name || "") &&
-          (<IconButton
-            color="primary"
-            aria-label="ver"
-            onClick={() => handleView(params.row.id)}
-          >
-            <VisibilityIcon />
-          </IconButton>)
-          }
-          {HasPermission(editProfessorPermission?.name || "") && (
-          <IconButton
-            color="primary"
-            aria-label="editar"
-            onClick={() => handleEdit(params.row.id)}
-          >
-            <EditIcon />
-          </IconButton>
-           )}
-          {HasPermission(deleteProfessorPermission?.name || "") && (
-          <IconButton
-            color="secondary"
-            aria-label="eliminar"
-            onClick={() => handleClickOpen(params.row.id)}
-          >
-            <DeleteIcon />
-          </IconButton>)}
-        </div>
-      ),
+      renderCell: (params) => {
+        const hasActions =
+          HasPermission(viewProfessorReportPermission?.name || "") ||
+          HasPermission(editProfessorPermission?.name || "") ||
+          HasPermission(deleteProfessorPermission?.name || "");
+    
+        return hasActions ? (
+          <div>
+            {HasPermission(viewProfessorReportPermission?.name || "") && (
+              <IconButton
+                color="primary"
+                aria-label="ver"
+                onClick={() => handleView(params.row.id)}
+              >
+                <VisibilityIcon />
+              </IconButton>
+            )}
+            {HasPermission(editProfessorPermission?.name || "") && (
+              <IconButton
+                color="primary"
+                aria-label="editar"
+                onClick={() => handleEdit(params.row.id)}
+              >
+                <EditIcon />
+              </IconButton>
+            )}
+            {HasPermission(deleteProfessorPermission?.name || "") && (
+              <IconButton
+                color="secondary"
+                aria-label="eliminar"
+                onClick={() => handleClickOpen(params.row.id)}
+              >
+                <DeleteIcon />
+              </IconButton>
+            )}
+          </div>
+        ) : (
+          "No hay acciones disponibles"
+        );
+      },
     },
   ];
-
+    
   const handleCreateTeacher = () => {
     navigate("/create-professor");
   };


### PR DESCRIPTION
Implementé y corregí
 el tamaño del mensaje en las columnas Tutorías y Revisiones dentro del módulo Docentes. Ahora los mensajes:
"No existen tutorías registradas"
"No existen revisiones disponibles"
se muestran correctamente en dos líneas, evitando que se oculten o desborden en la tabla.
![Imagen de WhatsApp 2025-03-28 a las 01 29 42_4d884ef4](https://github.com/user-attachments/assets/91c8be7a-e9cc-4e1f-a630-78e631e96f6b)
